### PR TITLE
Reduce required CMake version and only include Eigen3 if it has been found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 2.8.11)
 project(lwpr)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
@@ -27,8 +27,10 @@ include_directories(
   include
   ${CMAKE_CURRENT_BINARY_DIR}
   ${EXPAT_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
-) 
+)
+if (${EIGEN3_FOUND})
+  include_directories(${EIGEN3_INCLUDE_DIR})
+endif()
 
 set(LWPR_VERSION_STRING 1.2.6)
 set(LWPR_SOVERSION_STRING 1)


### PR DESCRIPTION
This PR brings in two changes:

a) It reduces the required CMake version. I couldn't find which feature of newer versions was required so I set it to 2.8.11 - 2.8.12 is standard on Trusty, 2.8.11 is on the compute cluster.

b) It will only include Eigen3_INCLUDE_DIRS if Eigen3 has been found (which fails for me on both Trusty and the cluster, by the way) - otherwise 2.8.11 will fail as it is trying to advance (i.e. it cannot deal with non-set variables)